### PR TITLE
Replace https?://mozilla.org with https://www.mozilla.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #moz://a protocol handler
 
-A moz: protocol handler for moz://a URLs. Maps moz://a to https://mozilla.org/
+A moz: protocol handler for moz://a URLs. Maps moz://a to https://www.mozilla.org/
 and moz://a/firefox to https://firefox.com/.
 
 Install it from its [addons.mozilla.org listing](https://addons.mozilla.org/en-US/firefox/addon/moz-a-protocol-handler/)

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 
 <script type="application/javascript">
 const urls = {
-  '':                 'https://mozilla.org',
+  '':                 'https://www.mozilla.org',
   'firefox':          'https://firefox.com/',
 };
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 
 <script type="application/javascript">
 const urls = {
-  '':                 'https://www.mozilla.org',
+  '':                 'https://www.mozilla.org/',
   'firefox':          'https://firefox.com/',
 };
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://www.mozilla.org/MPL/2.0/. */
 
 'use strict';
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://www.mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 'use strict';
 


### PR DESCRIPTION
- http://mozilla.org permanently redirects to https://www.mozilla.org
- mozilla.org is not as highly available as www.mozilla.org because it is only in one datacenter
- unlike https://www.mozilla.org, https://mozilla.org does not work in older browsers that do not support sha-256 signed certs
  - if you're on IE6 on XP SP2, typing mozilla.org into the url bar will still work because it uses http by default