### PR TITLE
enhance verbiage; remove reference to GitHub Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 #moz://a protocol handler
 
-A moz: protocol handler for moz://a URLs. Maps moz://a to https://www.mozilla.org/
-and moz://a/firefox to https://firefox.com/.
+A moz: protocol handler for moz://a URLs. Maps moz://a to https://www.mozilla.org/,
+moz://a/firefox to https://firefox.com/, and other Mozilla-related words to informative URLs.
 
-Install it from its [addons.mozilla.org listing](https://addons.mozilla.org/en-US/firefox/addon/moz-a-protocol-handler/)
-or its [GitHub release](https://github.com/mozilla/moz-handler/releases).
-
-See [docs/index.html](https://github.com/mozilla/moz-handler/blob/master/docs/index.html)
+Install it from its [addons.mozilla.org listing](https://addons.mozilla.org/en-US/firefox/addon/moz-a-protocol-handler/),
+and see [docs/index.html](https://github.com/mozilla/moz-handler/blob/master/docs/index.html)
 for the complete list of available mappings.


### PR DESCRIPTION
The GitHub release is a suboptimal way to distribute the extension, since it isn't signed, and thus you can't install it in Beta/Release, and you can only install it in Nightly/Aurora if you've set *xpinstall.signatures.required* to `false`. It's better to distribute the extension via AMO, and we're already doing so anyway, so I've removed the reference to the GitHub Release.