### PR TITLE
redirect firefox/nightly to URL that provides platform-specific build

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,7 +7,7 @@ const urls = {
   'developer':        'https://developer.mozilla.org/',
   'firefox':          'https://firefox.com/',
   'firefox/android':  'https://www.mozilla.org/firefox/android/',
-  'firefox/nightly':  'https://www.mozilla.org/firefox/channel/desktop/#nightly',
+  'firefox/nightly':  'https://nightly.mozilla.org/',
   'rust':             'https://www.rust-lang.org/',
   'rust-community':   'https://community.rs',
   'servo':            'https://servo.org',


### PR DESCRIPTION
Per https://github.com/mozilla/moz-handler/pull/2#discussion_r97419778.